### PR TITLE
fix(commands): add deferReply to prevent Unknown Interaction errors

### DIFF
--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -40,6 +40,8 @@ export const opencode: Command = {
       });
       return;
     }
+
+    await interaction.deferReply();
     
     let thread;
     try {
@@ -49,9 +51,8 @@ export const opencode: Command = {
         thread = await getOrCreateThread(interaction, prompt);
       }
     } catch {
-      await interaction.reply({
+      await interaction.editReply({
         content: '❌ Cannot create thread.',
-        flags: MessageFlags.Ephemeral
       });
       return;
     }
@@ -64,14 +65,13 @@ export const opencode: Command = {
         userId: interaction.user.id,
         timestamp: Date.now()
       });
-      await interaction.reply({
+      await interaction.editReply({
         content: '📥 Prompt added to queue.',
-        flags: MessageFlags.Ephemeral
       });
       return;
     }
 
-    await interaction.reply({
+    await interaction.editReply({
       content: `📌 **Prompt**: ${prompt}`
     });
 

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -65,6 +65,7 @@ export const work: Command = {
       return;
     }
 
+    await i.deferReply({ flags: MessageFlags.Ephemeral });
     try {
       const worktreePath = await worktreeManager.createWorktree(projectPath, sanitizedBranch);
 
@@ -113,16 +114,14 @@ export const work: Command = {
         components: [buttons]
       });
 
-      await i.reply({
+      await i.editReply({
         content: `✅ Created worktree **${sanitizedBranch}** -> <#${thread.id}>`,
-        flags: MessageFlags.Ephemeral
       });
 
     } catch (error) {
       console.error('Worktree creation failed:', error);
-      await i.reply({
+      await i.editReply({
         content: `❌ Failed to create worktree: ${(error as Error).message}`,
-        flags: MessageFlags.Ephemeral
       });
     }
   }


### PR DESCRIPTION
## Summary

Add `interaction.deferReply()` to `/opencode` and `/work` commands before slow async operations to prevent `DiscordAPIError[10062]: Unknown interaction` caused by exceeding Discord's 3-second interaction timeout.

## Related Issue

Closes #21

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- **`src/commands/opencode.ts`**: Added `interaction.deferReply()` after the project-path validation guard but before `getOrCreateThread()` (the slow Discord API call). Converted all subsequent `interaction.reply()` calls to `interaction.editReply()`.
- **`src/commands/work.ts`**: Added `i.deferReply({ flags: MessageFlags.Ephemeral })` after all five sync validation guards but before `worktreeManager.createWorktree()` and `threads.create()` (slow I/O + Discord API). Converted all subsequent `i.reply()` calls to `i.editReply()`.
- Early validation guards (e.g., "no project set", "not a text channel") still use `reply()` directly since they fire before `deferReply()` and are fast sync checks.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests (if applicable)
- [x] All existing tests pass (`npm test`)

### Manual test procedure:
1. Added a 5-second `setTimeout` delay in `getOrCreateThread()` to simulate slow network
2. Verified **without fix**: `/opencode` triggers `DiscordAPIError[10062]: Unknown interaction`
3. Verified **with fix**: `/opencode` shows "thinking..." indicator immediately, then responds normally after the delay

## Checklist

- [x] My code follows the existing code style
- [x] I have not included version bumps (maintainer handles versioning)
- [ ] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Additional Notes

This follows the same `deferReply()` → `editReply()` pattern already used in `/model` (`model.ts:40`), `/diff` (`diff.ts:90`), and button handlers (`buttonHandler.ts:59/77/108`). The `interactionHandler.ts` error handler already checks `interaction.replied || interaction.deferred`, so it works correctly with this change without modification.