### PR TITLE
fix(execution): prevent silent error swallowing in Discord message handling

### DIFF
--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -112,10 +112,23 @@ export async function runPrompt(
   let hasSessionError = false;
   const spinner = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   
-  const updateStreamMessage = async (content: string, components: ActionRowBuilder<ButtonBuilder>[]) => {
+  const updateStreamMessage = async (content: string, components: ActionRowBuilder<ButtonBuilder>[]): Promise<boolean> => {
     try {
       await streamMessage.edit({ content, components });
-    } catch {
+      return true;
+    } catch (error) {
+      console.error('Failed to edit stream message:', error instanceof Error ? error.message : error);
+      return false;
+    }
+  };
+
+  const safeSend = async (content: string): Promise<boolean> => {
+    try {
+      await (channel as any).send({ content });
+      return true;
+    } catch (error) {
+      console.error('Failed to send message:', error instanceof Error ? error.message : error);
+      return false;
     }
   };
   
@@ -183,24 +196,29 @@ export async function runPrompt(
             );
 
           if (!accumulatedText.trim()) {
-            await updateStreamMessage(
+            const edited = await updateStreamMessage(
               `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n⚠️ No output received — the model may have encountered an issue.`,
               [disabledButtons]
             );
-            await (channel as any).send({ content: '⚠️ Done (no output received)' });
+            if (!edited) {
+              await safeSend('⚠️ No output received — the model may have encountered an issue.');
+            }
+            await safeSend('⚠️ Done (no output received)');
           } else {
             const result = formatOutputForMobile(accumulatedText);
             
-            await updateStreamMessage(
+            const editSuccess = await updateStreamMessage(
               `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n${result.chunks[0]}`,
               [disabledButtons]
             );
             
-            for (let i = 1; i < result.chunks.length; i++) {
-              await (channel as any).send({ content: result.chunks[i] });
+            // If edit failed (e.g., content exceeds Discord's 2000-char limit), send all chunks as new messages
+            const startIndex = editSuccess ? 1 : 0;
+            for (let i = startIndex; i < result.chunks.length; i++) {
+              await safeSend(result.chunks[i]);
             }
             
-            await (channel as any).send({ content: '✅ Done' });
+            await safeSend('✅ Done');
           }
           
           sseClient.disconnect();
@@ -209,6 +227,7 @@ export async function runPrompt(
           await processNextInQueue(channel, threadId, parentChannelId);
         } catch (error) {
           console.error('Error in onSessionIdle:', error);
+          await safeSend('❌ An unexpected error occurred while processing the response.');
         }
       })();
     });
@@ -236,10 +255,13 @@ export async function runPrompt(
                 .setDisabled(true)
             );
           
-          await updateStreamMessage(
+          const edited = await updateStreamMessage(
             `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ **Error**: ${errorMsg}`,
             [disabledButtons]
           );
+          if (!edited) {
+            await safeSend(`❌ **Error**: ${errorMsg}`);
+          }
           
           sseClient.disconnect();
           sessionManager.clearSseClient(threadId);
@@ -249,10 +271,11 @@ export async function runPrompt(
             await processNextInQueue(channel, threadId, parentChannelId);
           } else {
             dataStore.clearQueue(threadId);
-            await (channel as any).send('❌ Execution failed. Queue cleared. Use `/queue settings` to change this behavior.');
+            await safeSend('❌ Execution failed. Queue cleared. Use `/queue settings` to change this behavior.');
           }
         } catch (error) {
           console.error('Error in onSessionError:', error);
+          await safeSend('❌ An unexpected error occurred while handling a session error.');
         }
       })();
     });
@@ -265,7 +288,10 @@ export async function runPrompt(
       
       (async () => {
         try {
-          await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ Connection error: ${error.message}`, []);
+          const edited = await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ Connection error: ${error.message}`, []);
+          if (!edited) {
+            await safeSend(`❌ Connection error: ${error.message}`);
+          }
           
           sseClient.disconnect();
           sessionManager.clearSseClient(threadId);
@@ -275,9 +301,11 @@ export async function runPrompt(
             await processNextInQueue(channel, threadId, parentChannelId);
           } else {
             dataStore.clearQueue(threadId);
-            await (channel as any).send('❌ Execution failed. Queue cleared. Use `/queue settings` to change this behavior.');
+            await safeSend('❌ Execution failed. Queue cleared. Use `/queue settings` to change this behavior.');
           }
-        } catch {
+        } catch (handlerError) {
+          console.error('Error in SSE onError handler:', handlerError);
+          await safeSend('❌ An unexpected connection error occurred.');
         }
       })();
     });
@@ -296,7 +324,8 @@ export async function runPrompt(
             [buttons]
           );
         }
-      } catch {
+      } catch (error) {
+        console.error('Error in stream update interval:', error instanceof Error ? error.message : error);
       }
     }, 1000);
     
@@ -310,7 +339,10 @@ export async function runPrompt(
     }
     
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ OpenCode execution failed: ${errorMessage}`, []);
+    const edited = await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ OpenCode execution failed: ${errorMessage}`, []);
+    if (!edited) {
+      await safeSend(`❌ OpenCode execution failed: ${errorMessage}`);
+    }
     
     const client = sessionManager.getSseClient(threadId);
     if (client) {
@@ -323,7 +355,7 @@ export async function runPrompt(
       await processNextInQueue(channel, threadId, parentChannelId);
     } else {
       dataStore.clearQueue(threadId);
-      await (channel as any).send('❌ Execution failed. Queue cleared.');
+      await safeSend('❌ Execution failed. Queue cleared.');
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where errors in `executionService.ts` were silently swallowed, causing AI responses to be lost while users only saw `✅ Done` with no actual output.

## Related Issue

Closes #32

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Changed `updateStreamMessage` to return a `boolean` indicating edit success/failure, with error logging
- Added `safeSend` helper for fallback message delivery with error logging
- **onSessionIdle (success path)**: When the final message edit fails (e.g., content exceeds Discord's 2000-char limit), all output chunks are now sent as new messages instead of being silently lost
- **onSessionIdle (no-output path)**: Added fallback when the warning edit fails
- **onSessionIdle (outer catch)**: Now sends an error notification to Discord instead of only logging to server console
- **onSessionError**: Added fallback new message when the error edit fails
- **onError**: Added error logging and Discord fallback to the previously empty catch block
- **setInterval catch**: Added `console.error` to the previously empty catch block
- **Outer catch**: Added fallback new message when the error edit fails
- Fixed variable shadowing in `onError` handler (`error` → `handlerError`)

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests (if applicable)
- [x] All existing tests pass (`npm test`) — 118 tests across 8 suites

## Checklist

- [x] My code follows the existing code style
- [x] I have not included version bumps (maintainer handles versioning)
- [x] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Additional Notes

**Root cause analysis**: The `updateStreamMessage` function had a completely empty `catch` block that swallowed all errors. When the final message edit failed (most likely due to content exceeding Discord's 2000-character limit when `contextHeader + prompt + chunk[0]` combined), the AI response was permanently lost — but `✅ Done` was sent as a separate new message, making it appear as if the bot completed successfully with no output.

**Approach**: Rather than changing the chunking logic (which would require changes across multiple files), this fix adds a fallback path: if editing the stream message fails for any reason, the content is sent as new message(s) instead. This ensures users always see either the AI output or a clear error message, regardless of what goes wrong with message editing.