### PR TITLE
Add proxy support for Discord requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Proxy support for Discord and other external HTTP requests via `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
+
+### Fixed
+- Automatic proxy bypass for local `opencode serve` traffic on `localhost`, `127.0.0.1`, and `::1`, preventing remote-control flows from breaking behind a proxy.
+
 ## [1.5.0] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ https://github.com/user-attachments/assets/59cf162a-ec86-41b5-a1f3-9b1379acd9fd
 
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [Proxy Support](#proxy-support)
 - [Discord Bot Setup](#discord-bot-setup)
 - [CLI Commands](#cli-commands)
 - [Discord Slash Commands](#discord-slash-commands)
@@ -111,6 +112,36 @@ remote-opencode start
 ```
 
 That's it! Now use Discord slash commands to interact with OpenCode.
+
+---
+
+## Proxy Support
+
+`remote-opencode` supports HTTP proxy environments for Discord and other external API requests.
+
+Supported environment variables:
+
+- `HTTP_PROXY`
+- `HTTPS_PROXY`
+- `ALL_PROXY`
+- `NO_PROXY`
+
+Proxy settings are applied app-wide. Local OpenCode traffic is kept direct automatically, so `localhost`, `127.0.0.1`, and `::1` are always excluded from proxying.
+
+### Example
+
+```bash
+export HTTPS_PROXY=http://proxy.company.local:8080
+export NO_PROXY=internal.company.local
+remote-opencode start
+```
+
+If your network uses a single proxy for everything, `ALL_PROXY` is also supported:
+
+```bash
+export ALL_PROXY=http://proxy.company.local:8080
+remote-opencode start
+```
 
 ---
 
@@ -697,6 +728,12 @@ The bot maintains persistent sessions. If you encounter issues:
    ```bash
    remote-opencode setup
    ```
+
+### Proxy environments still fail
+
+1. Confirm `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` is set in the same shell where you start the bot
+2. Check whether a custom `NO_PROXY` value is excluding a required remote host
+3. Leave loopback traffic direct; the bot already auto-adds `localhost`, `127.0.0.1`, and `::1`
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "open": "^10.1.0",
         "opencode-antigravity-auth": "^1.4.6",
         "picocolors": "^1.1.1",
+        "undici": "^6.23.0",
         "update-notifier": "^7.3.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "open": "^10.1.0",
     "opencode-antigravity-auth": "^1.4.6",
     "picocolors": "^1.1.1",
+    "undici": "^6.23.0",
     "update-notifier": "^7.3.1"
   },
   "devDependencies": {

--- a/src/__tests__/bot.test.ts
+++ b/src/__tests__/bot.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const order: string[] = [];
+  const mockLogin = vi.fn(async () => {
+    order.push('login');
+  });
+  const mockOnce = vi.fn();
+  const mockOn = vi.fn();
+  const mockDestroy = vi.fn();
+  const mockClient = {
+    once: mockOnce,
+    on: mockOn,
+    login: mockLogin,
+    destroy: mockDestroy,
+  };
+
+  return {
+    order,
+    mockLogin,
+    mockOnce,
+    mockOn,
+    mockDestroy,
+    mockClient,
+    ClientMock: vi.fn(() => mockClient),
+    initializeProxySupport: vi.fn(() => {
+      order.push('proxy');
+    }),
+  };
+});
+
+vi.mock('discord.js', () => ({
+  Client: class MockClient {
+    constructor() {
+      mocks.ClientMock();
+      return mocks.mockClient;
+    }
+  },
+  GatewayIntentBits: {
+    Guilds: 1,
+    GuildMessages: 2,
+    MessageContent: 4,
+  },
+  Events: {
+    ClientReady: 'ready',
+    InteractionCreate: 'interactionCreate',
+    MessageCreate: 'messageCreate',
+  },
+}));
+
+vi.mock('../services/configStore.js', () => ({
+  getBotConfig: vi.fn(() => ({
+    discordToken: 'discord-token',
+    clientId: 'client-id',
+    guildId: 'guild-id',
+  })),
+}));
+
+vi.mock('../handlers/interactionHandler.js', () => ({
+  handleInteraction: vi.fn(),
+}));
+
+vi.mock('../handlers/messageHandler.js', () => ({
+  handleMessageCreate: vi.fn(),
+}));
+
+vi.mock('../services/serveManager.js', () => ({
+  stopAll: vi.fn(),
+}));
+
+vi.mock('../services/proxySupport.js', () => ({
+  initializeProxySupport: mocks.initializeProxySupport,
+}));
+
+vi.mock('../commands/model.js', () => ({
+  getCachedModels: vi.fn(),
+}));
+
+describe('startBot', () => {
+  beforeEach(() => {
+    mocks.order.length = 0;
+    vi.clearAllMocks();
+    vi.spyOn(process, 'on').mockImplementation(() => process);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes proxy support before logging in to Discord', async () => {
+    const { startBot } = await import('../bot.js');
+
+    await startBot();
+
+    expect(mocks.order).toEqual(['proxy', 'login']);
+    expect(mocks.initializeProxySupport).toHaveBeenCalledTimes(1);
+    expect(mocks.mockLogin).toHaveBeenCalledWith('discord-token');
+  });
+});

--- a/src/__tests__/deploy.test.ts
+++ b/src/__tests__/deploy.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const order: string[] = [];
+  const mockPut = vi.fn(async () => {
+    order.push('put');
+  });
+  const mockSetToken = vi.fn(function (this: unknown) {
+    return this;
+  });
+
+  return {
+    order,
+    mockPut,
+    mockSetToken,
+    RESTMock: vi.fn(() => ({
+      setToken: mockSetToken,
+      put: mockPut,
+    })),
+    initializeProxySupport: vi.fn(() => {
+      order.push('proxy');
+    }),
+  };
+});
+
+vi.mock('discord.js', () => ({
+  REST: class MockREST {
+    constructor() {
+      mocks.RESTMock();
+      return {
+        setToken: mocks.mockSetToken,
+        put: mocks.mockPut,
+      };
+    }
+  },
+  Routes: {
+    applicationGuildCommands: vi.fn(() => '/applications/client-id/guilds/guild-id/commands'),
+  },
+}));
+
+vi.mock('../services/configStore.js', () => ({
+  getBotConfig: vi.fn(() => ({
+    discordToken: 'discord-token',
+    clientId: 'client-id',
+    guildId: 'guild-id',
+  })),
+}));
+
+vi.mock('../commands/index.js', () => ({
+  commands: new Map([
+    ['ping', { data: { toJSON: () => ({ name: 'ping' }) } }],
+  ]),
+}));
+
+vi.mock('../services/proxySupport.js', () => ({
+  initializeProxySupport: mocks.initializeProxySupport,
+}));
+
+describe('deployCommands', () => {
+  beforeEach(() => {
+    mocks.order.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes proxy support before deploying commands', async () => {
+    const { deployCommands } = await import('../setup/deploy.js');
+
+    await deployCommands();
+
+    expect(mocks.order).toEqual(['proxy', 'put']);
+    expect(mocks.initializeProxySupport).toHaveBeenCalledTimes(1);
+    expect(mocks.mockSetToken).toHaveBeenCalledWith('discord-token');
+    expect(mocks.mockPut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/proxySupport.test.ts
+++ b/src/__tests__/proxySupport.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+const mockSetGlobalDispatcher = vi.fn();
+const mockEnvHttpProxyAgent = vi.fn((options: unknown) => ({ options }));
+
+async function loadProxySupport() {
+  vi.resetModules();
+  vi.doMock('undici', () => ({
+    EnvHttpProxyAgent: class MockEnvHttpProxyAgent {
+      constructor(options: unknown) {
+        return mockEnvHttpProxyAgent(options);
+      }
+    },
+    setGlobalDispatcher: mockSetGlobalDispatcher,
+  }));
+
+  return import('../services/proxySupport.js');
+}
+
+describe('proxySupport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('does nothing when no proxy environment variables are set', async () => {
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.ALL_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.all_proxy;
+
+    const { initializeProxySupport } = await loadProxySupport();
+
+    expect(initializeProxySupport()).toBe(false);
+    expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+    expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('initializes dispatcher when only HTTPS_PROXY is set', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.internal:8443';
+
+    const { initializeProxySupport } = await loadProxySupport();
+
+    expect(initializeProxySupport()).toBe(true);
+    expect(mockEnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpsProxy: 'http://proxy.internal:8443',
+      noProxy: 'localhost,127.0.0.1,::1',
+    });
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to ALL_PROXY for both http and https requests', async () => {
+    process.env.ALL_PROXY = 'http://proxy.internal:8080';
+
+    const { initializeProxySupport } = await loadProxySupport();
+
+    initializeProxySupport();
+
+    expect(mockEnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: 'http://proxy.internal:8080',
+      httpsProxy: 'http://proxy.internal:8080',
+      noProxy: 'localhost,127.0.0.1,::1',
+    });
+  });
+
+  it('merges existing NO_PROXY entries with loopback defaults', async () => {
+    process.env.HTTP_PROXY = 'http://proxy.internal:8080';
+    process.env.NO_PROXY = 'internal.example.com, localhost  ,10.0.0.5';
+
+    const { initializeProxySupport } = await loadProxySupport();
+
+    initializeProxySupport();
+
+    expect(mockEnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: 'http://proxy.internal:8080',
+      httpsProxy: 'http://proxy.internal:8080',
+      noProxy: 'internal.example.com,localhost,10.0.0.5,127.0.0.1,::1',
+    });
+  });
+
+  it('initializes the dispatcher only once', async () => {
+    process.env.HTTP_PROXY = 'http://proxy.internal:8080';
+
+    const { initializeProxySupport, resetProxySupportForTests } = await loadProxySupport();
+
+    expect(initializeProxySupport()).toBe(true);
+    expect(initializeProxySupport()).toBe(false);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+
+    resetProxySupportForTests();
+    expect(initializeProxySupport()).toBe(true);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/sessionManager.test.ts
+++ b/src/__tests__/sessionManager.test.ts
@@ -1,4 +1,32 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+const dataStoreMock = vi.hoisted(() => {
+  const threadSessions = new Map<string, { threadId: string; sessionId: string; projectPath: string; port: number; createdAt: number; lastUsedAt: number }>();
+
+  return {
+    reset: () => threadSessions.clear(),
+    getThreadSession: vi.fn((threadId: string) => threadSessions.get(threadId)),
+    setThreadSession: vi.fn((session: { threadId: string; sessionId: string; projectPath: string; port: number; createdAt: number; lastUsedAt: number }) => {
+      threadSessions.set(session.threadId, session);
+    }),
+    updateThreadSessionLastUsed: vi.fn((threadId: string) => {
+      const session = threadSessions.get(threadId);
+      if (session) {
+        session.lastUsedAt = Date.now();
+      }
+    }),
+    clearThreadSession: vi.fn((threadId: string) => {
+      threadSessions.delete(threadId);
+    }),
+  };
+});
+
+vi.mock('../services/dataStore.js', () => ({
+  getThreadSession: dataStoreMock.getThreadSession,
+  setThreadSession: dataStoreMock.setThreadSession,
+  updateThreadSessionLastUsed: dataStoreMock.updateThreadSessionLastUsed,
+  clearThreadSession: dataStoreMock.clearThreadSession,
+}));
+
 import {
   createSession,
   sendPrompt,
@@ -17,6 +45,8 @@ describe('SessionManager', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch);
     mockFetch.mockReset();
+    dataStoreMock.reset();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -4,6 +4,7 @@ import { getBotConfig } from './services/configStore.js';
 import { handleInteraction } from './handlers/interactionHandler.js';
 import { handleMessageCreate } from './handlers/messageHandler.js';
 import * as serveManager from './services/serveManager.js';
+import { initializeProxySupport } from './services/proxySupport.js';
 import { getCachedModels } from './commands/model.js';
 
 export async function startBot(): Promise<void> {
@@ -45,6 +46,7 @@ export async function startBot(): Promise<void> {
   process.on('SIGINT', () => gracefulShutdown('SIGINT'));
   process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
   
+  initializeProxySupport();
   console.log(pc.dim('Connecting to Discord...'));
   await client.login(config.discordToken);
 }

--- a/src/services/proxySupport.ts
+++ b/src/services/proxySupport.ts
@@ -1,0 +1,67 @@
+import pc from 'picocolors';
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+
+const LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1'];
+
+let initialized = false;
+
+function getEnvValue(names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function mergeNoProxy(existing: string | undefined): string {
+  const merged = new Set(
+    (existing ?? '')
+      .split(/[,\s]+/)
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+
+  for (const value of LOOPBACK_NO_PROXY) {
+    merged.add(value);
+  }
+
+  return Array.from(merged).join(',');
+}
+
+export function initializeProxySupport(): boolean {
+  const allProxy = getEnvValue(['all_proxy', 'ALL_PROXY']);
+  const httpProxy = getEnvValue(['http_proxy', 'HTTP_PROXY']) ?? allProxy;
+  const httpsProxy = getEnvValue(['https_proxy', 'HTTPS_PROXY']) ?? httpProxy ?? allProxy;
+
+  if (!httpProxy && !httpsProxy) {
+    return false;
+  }
+
+  if (initialized) {
+    return false;
+  }
+
+  const noProxy = mergeNoProxy(getEnvValue(['no_proxy', 'NO_PROXY']));
+  const options: { httpProxy?: string; httpsProxy?: string; noProxy: string } = { noProxy };
+
+  if (httpProxy) {
+    options.httpProxy = httpProxy;
+  }
+
+  if (httpsProxy) {
+    options.httpsProxy = httpsProxy;
+  }
+
+  setGlobalDispatcher(new EnvHttpProxyAgent(options));
+  initialized = true;
+
+  console.log(pc.dim('Proxy support enabled via environment.'));
+  return true;
+}
+
+export function resetProxySupportForTests(): void {
+  initialized = false;
+}

--- a/src/setup/deploy.ts
+++ b/src/setup/deploy.ts
@@ -1,6 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import { getBotConfig } from '../services/configStore.js';
 import { commands } from '../commands/index.js';
+import { initializeProxySupport } from '../services/proxySupport.js';
 import pc from 'picocolors';
 
 export async function deployCommands(): Promise<void> {
@@ -13,6 +14,7 @@ export async function deployCommands(): Promise<void> {
   const commandsData = Array.from(commands.values()).map(c => c.data.toJSON());
   const rest = new REST({ version: '10' }).setToken(config.discordToken);
   
+  initializeProxySupport();
   console.log(pc.dim(`Deploying ${commandsData.length} commands...`));
   
   await rest.put(


### PR DESCRIPTION
## Summary

Add app-wide proxy support for Discord and other external HTTP requests using `undici`'s `EnvHttpProxyAgent`, while always bypassing loopback traffic so local `opencode serve` communication keeps working.

## Related Issue

Closes #37

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added a shared proxy initialization module that reads `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`, then configures a global `EnvHttpProxyAgent`
- Ensured `localhost`, `127.0.0.1`, and `::1` are always bypassed so local OpenCode session and SSE traffic do not get sent through the proxy
- Initialized proxy support before Discord login and slash-command deployment, added targeted tests, and documented proxy setup and troubleshooting

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests (if applicable)
- [x] All existing tests pass (`npm test`)

## Checklist

- [x] My code follows the existing code style
- [x] I have not included version bumps (maintainer handles versioning)
- [x] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Screenshots (if applicable)

N/A

## Additional Notes

- This implementation uses app-level proxy initialization rather than relying on Node runtime flags
- `ALL_PROXY` is mapped explicitly so environments with a single proxy endpoint are supported as well
- Verified locally with `npm test` and `npm run build`
