### PR TITLE
fix(serve): remove shell-based opencode spawn

### DIFF
--- a/src/__tests__/serveManager.test.ts
+++ b/src/__tests__/serveManager.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
@@ -42,12 +45,18 @@ const createMockProcess = (): ChildProcess => {
 };
 
 describe('serveManager', () => {
+  let originalPath: string | undefined;
+
   beforeEach(() => {
     vi.resetAllMocks();
+    originalPath = process.env.PATH;
+    vi.stubEnv('PATH', '/nonexistent');
   });
 
   afterEach(() => {
     serveManager.stopAll();
+    vi.unstubAllEnvs();
+    process.env.PATH = originalPath;
   });
 
   describe('spawnServe', () => {
@@ -65,9 +74,31 @@ describe('serveManager', () => {
         ['serve', '--port', port.toString()],
         expect.objectContaining({
           cwd: projectPath,
-          shell: true,
+          stdio: ['inherit', 'pipe', 'pipe'],
         })
       );
+
+      const spawnOptions = vi.mocked(spawn).mock.calls[0]?.[2];
+      expect(spawnOptions).not.toHaveProperty('shell');
+    });
+
+    it('should resolve opencode from PATH before spawning', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'remote-opencode-'));
+      const executableName = process.platform === 'win32' ? 'opencode.cmd' : 'opencode';
+      const resolvedPath = join(tempDir, executableName);
+
+      writeFileSync(resolvedPath, '@echo off');
+      vi.stubEnv('PATH', tempDir);
+
+      const mockProc = createMockProcess();
+      vi.mocked(spawn).mockReturnValue(mockProc);
+
+      try {
+        await serveManager.spawnServe('/test/project');
+        expect(vi.mocked(spawn).mock.calls[0]?.[0]).toBe(resolvedPath);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
 
     it('should return existing port if serve already running for project', async () => {
@@ -149,16 +180,36 @@ describe('serveManager', () => {
       const mockProc = createMockProcess();
       vi.mocked(spawn).mockReturnValue(mockProc);
 
-      const projectPath = '/test/project';
+      const projectPath = process.cwd();
       await serveManager.spawnServe(projectPath);
 
-      mockProc.emit('error', new Error('spawn opencode ENOENT'));
+      const error = new Error('spawn opencode ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      mockProc.emit('error', error);
 
       await new Promise(resolve => setTimeout(resolve, 10));
 
       const state = serveManager.getInstanceState(projectPath);
       expect(state?.exited).toBe(true);
-      expect(state?.exitError).toContain('spawn opencode ENOENT');
+      expect(state?.exitError).toContain('OpenCode executable not found');
+    });
+
+    it('should report missing project path when spawn fails with inaccessible cwd', async () => {
+      const mockProc = createMockProcess();
+      vi.mocked(spawn).mockReturnValue(mockProc);
+
+      const projectPath = '/definitely/missing/project-path';
+      await serveManager.spawnServe(projectPath);
+
+      const error = new Error('spawn opencode ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      mockProc.emit('error', error);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const state = serveManager.getInstanceState(projectPath);
+      expect(state?.exited).toBe(true);
+      expect(state?.exitError).toContain(`Project path does not exist or is not accessible: ${projectPath}`);
     });
 
     it('should allow respawning after process exits', async () => {

--- a/src/__tests__/sessionManager.test.ts
+++ b/src/__tests__/sessionManager.test.ts
@@ -30,6 +30,7 @@ vi.mock('../services/dataStore.js', () => ({
 import {
   createSession,
   sendPrompt,
+  ensureSessionForThread,
   getSessionForThread,
   setSessionForThread,
   clearSessionForThread,
@@ -182,6 +183,66 @@ describe('SessionManager', () => {
       const result = getSessionForThread('thread3');
 
       expect(result).toEqual({ sessionId: 'ses_new', projectPath: '/path/to/new', port: 4003 });
+    });
+
+    it('should preserve createdAt when updating an existing thread session', () => {
+      setSessionForThread('thread4', 'ses_original', '/path/to/project', 4004);
+      const original = dataStoreMock.getThreadSession('thread4');
+
+      setSessionForThread('thread4', 'ses_original', '/path/to/project', 4005);
+
+      const updated = dataStoreMock.getThreadSession('thread4');
+      expect(updated?.createdAt).toBe(original?.createdAt);
+      expect(updated?.port).toBe(4005);
+    });
+  });
+
+  describe('ensureSessionForThread', () => {
+    it('should reuse and refresh an existing valid session', async () => {
+      setSessionForThread('thread5', 'ses_valid', '/path/to/project', 4000);
+      const original = dataStoreMock.getThreadSession('thread5');
+
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      const sessionId = await ensureSessionForThread('thread5', '/path/to/project', 4010);
+
+      const updated = dataStoreMock.getThreadSession('thread5');
+      expect(sessionId).toBe('ses_valid');
+      expect(updated?.sessionId).toBe('ses_valid');
+      expect(updated?.port).toBe(4010);
+      expect(updated?.createdAt).toBe(original?.createdAt);
+    });
+
+    it('should create and persist a new session when the stored one is invalid', async () => {
+      setSessionForThread('thread6', 'ses_stale', '/path/to/project', 4000);
+      const original = dataStoreMock.getThreadSession('thread6');
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'ses_new' }) });
+
+      const sessionId = await ensureSessionForThread('thread6', '/path/to/project', 4011);
+
+      const updated = dataStoreMock.getThreadSession('thread6');
+      expect(sessionId).toBe('ses_new');
+      expect(updated?.sessionId).toBe('ses_new');
+      expect(updated?.port).toBe(4011);
+      expect(updated?.createdAt).toBe(original?.createdAt);
+    });
+
+    it('should create a new session when the stored project path no longer matches', async () => {
+      setSessionForThread('thread7', 'ses_old', '/path/to/old', 4000);
+
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: 'ses_project_new' }) });
+
+      const sessionId = await ensureSessionForThread('thread7', '/path/to/new', 4012);
+
+      const updated = dataStoreMock.getThreadSession('thread7');
+      expect(sessionId).toBe('ses_project_new');
+      expect(updated?.sessionId).toBe('ses_project_new');
+      expect(updated?.projectPath).toBe('/path/to/new');
+      expect(updated?.port).toBe(4012);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/handlers/buttonHandler.ts
+++ b/src/handlers/buttonHandler.ts
@@ -111,15 +111,7 @@ async function handleWorktreePR(interaction: ButtonInteraction, threadId: string
     const port = await serveManager.spawnServe(mapping.worktreePath, preferredModel);
     await serveManager.waitForReady(port, 30000, mapping.worktreePath, preferredModel);
 
-    let sessionId: string;
-    const existingSession = sessionManager.getSessionForThread(threadId);
-    if (existingSession) {
-      const isValid = await sessionManager.validateSession(port, existingSession.sessionId);
-      sessionId = isValid ? existingSession.sessionId : await sessionManager.createSession(port);
-    } else {
-      sessionId = await sessionManager.createSession(port);
-    }
-    sessionManager.setSessionForThread(threadId, sessionId, mapping.worktreePath, port);
+    const sessionId = await sessionManager.ensureSessionForThread(threadId, mapping.worktreePath, port);
 
     const prPrompt = `Create a pull request for the current branch. Include a clear title and description summarizing all changes.`;
     await sessionManager.sendPrompt(port, sessionId, prPrompt, preferredModel);

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -145,20 +145,7 @@ export async function runPrompt(
       sessionManager.clearSessionForThread(threadId);
     }
 
-    const existingSession = sessionManager.getSessionForThread(threadId);
-    if (existingSession && existingSession.projectPath === effectivePath) {
-      const isValid = await sessionManager.validateSession(port, existingSession.sessionId);
-      if (isValid) {
-        sessionId = existingSession.sessionId;
-        sessionManager.updateSessionLastUsed(threadId);
-      } else {
-        sessionId = await sessionManager.createSession(port);
-        sessionManager.setSessionForThread(threadId, sessionId, effectivePath, port);
-      }
-    } else {
-      sessionId = await sessionManager.createSession(port);
-      sessionManager.setSessionForThread(threadId, sessionId, effectivePath, port);
-    }
+    sessionId = await sessionManager.ensureSessionForThread(threadId, effectivePath, port);
     
     const sseClient = new SSEClient();
     sseClient.connect(`http://127.0.0.1:${port}`);

--- a/src/services/serveManager.ts
+++ b/src/services/serveManager.ts
@@ -1,12 +1,70 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { Server } from 'node:net';
+import { delimiter, join } from 'node:path';
 import type { ServeInstance } from '../types/index.js';
 import { getPortConfig } from './configStore.js';
 
 const DEFAULT_PORT_MIN = 14097;
 const DEFAULT_PORT_MAX = 14200;
+const WINDOWS_OPENCODE_COMMANDS = ['opencode.cmd', 'opencode.exe', 'opencode'];
+const POSIX_OPENCODE_COMMANDS = ['opencode'];
 
 const instances = new Map<string, ServeInstance>();
+
+function getOpencodeCommandCandidates(): string[] {
+  return process.platform === 'win32' ? WINDOWS_OPENCODE_COMMANDS : POSIX_OPENCODE_COMMANDS;
+}
+
+function resolveCommandFromPath(command: string, pathValue?: string): string | undefined {
+  if (!pathValue) {
+    return undefined;
+  }
+
+  for (const pathEntry of pathValue.split(delimiter)) {
+    if (!pathEntry) {
+      continue;
+    }
+
+    const resolved = join(pathEntry, command);
+    if (existsSync(resolved)) {
+      return resolved;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveOpencodeCommand(env: NodeJS.ProcessEnv): string {
+  const pathValue = env.PATH ?? env.Path;
+
+  for (const command of getOpencodeCommandCandidates()) {
+    const resolved = resolveCommandFromPath(command, pathValue);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return getOpencodeCommandCandidates()[0];
+}
+
+function formatSpawnError(error: Error, command: string, projectPath: string): string {
+  const spawnError = error as NodeJS.ErrnoException;
+
+  if (!existsSync(projectPath)) {
+    return `Project path does not exist or is not accessible: ${projectPath}`;
+  }
+
+  if (spawnError.code === 'ENOENT') {
+    return `OpenCode executable not found: ${command}. Ensure OpenCode is installed and available in PATH for this service.`;
+  }
+
+  if (spawnError.code === 'EACCES') {
+    return `OpenCode executable is not accessible: ${command}. Check file permissions and service user access.`;
+  }
+
+  return spawnError.message || 'Failed to spawn opencode process';
+}
 
 function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -95,15 +153,16 @@ export async function spawnServe(projectPath: string, model?: string): Promise<n
   // Note: opencode serve doesn't support --model flag
   // Model selection must happen at session/prompt level, not server startup
   const args = ['serve', '--port', port.toString()];
+  const env = { ...process.env };
+  const command = resolveOpencodeCommand(env);
   
-  console.log(`[opencode] Spawning: opencode ${args.join(' ')}`);
+  console.log(`[opencode] Spawning: ${command} ${args.join(' ')}`);
   console.log(`[opencode] Working directory: ${projectPath}`);
   
-  const child = spawn('opencode', args, {
+  const child = spawn(command, args, {
     cwd: projectPath,
-    env: { ...process.env },
+    env,
     stdio: ['inherit', 'pipe', 'pipe'],
-    shell: true,
   });
 
   const instance: ServeInstance = {
@@ -154,11 +213,12 @@ export async function spawnServe(projectPath: string, model?: string): Promise<n
   });
 
   child.on('error', (error) => {
-    console.error(`[opencode] Spawn error: ${error.message}`);
+    const formattedError = formatSpawnError(error, command, projectPath);
+    console.error(`[opencode] Spawn error: ${formattedError}`);
     const inst = instances.get(key);
     if (inst) {
       inst.exited = true;
-      inst.exitError = error.message || 'Failed to spawn opencode process';
+      inst.exitError = formattedError;
     }
   });
 

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -140,15 +140,32 @@ export function getSessionForThread(threadId: string): { sessionId: string; proj
 }
 
 export function setSessionForThread(threadId: string, sessionId: string, projectPath: string, port: number): void {
+  const existing = dataStore.getThreadSession(threadId);
   const now = Date.now();
   dataStore.setThreadSession({
     threadId,
     sessionId,
     projectPath,
     port,
-    createdAt: now,
+    createdAt: existing?.createdAt ?? now,
     lastUsedAt: now,
   });
+}
+
+export async function ensureSessionForThread(threadId: string, projectPath: string, port: number): Promise<string> {
+  const existingSession = getSessionForThread(threadId);
+
+  if (existingSession && existingSession.projectPath === projectPath) {
+    const isValid = await validateSession(port, existingSession.sessionId);
+    if (isValid) {
+      setSessionForThread(threadId, existingSession.sessionId, projectPath, port);
+      return existingSession.sessionId;
+    }
+  }
+
+  const sessionId = await createSession(port);
+  setSessionForThread(threadId, sessionId, projectPath, port);
+  return sessionId;
 }
 
 export function updateSessionLastUsed(threadId: string): void {


### PR DESCRIPTION
## Summary

This PR removes the shell-based `opencode serve` launch path so service environments no longer depend on `/bin/sh`. It also keeps persisted thread-session mappings usable by reusing valid sessions and recreating stale ones without resetting stored thread metadata.

## Related Issue

Closes #40

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- remove `shell: true` from OpenCode server startup and resolve the executable directly from `PATH`
- improve spawn failure messages for missing executables and inaccessible project paths
- centralize thread-session recovery so valid sessions are reused and stale sessions are recreated while preserving stored metadata

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests (if applicable)
- [x] All existing tests pass (`npm test`)

## Checklist

- [x] My code follows the existing code style
- [x] I have not included version bumps (maintainer handles versioning)
- [ ] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Screenshots (if applicable)

N/A

## Additional Notes

An unrelated local deletion in `final_report.md` was intentionally left out of this PR.