### PR TITLE
docs: clarify Discord channel access for threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ If you prefer manual setup or need to troubleshoot:
    ```
    https://discord.com/api/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=2147534848&scope=bot+applications.commands
    ```
+6. **Check Channel Access**: For private or restricted channels, make sure the bot user or bot role can access the channel.
 
 </details>
 
@@ -683,6 +684,10 @@ You need to bind a project to the channel:
 /setpath alias:myproject path:/path/to/project
 /use alias:myproject
 ```
+
+### "Cannot create thread"
+
+For private or restricted channels, make sure the bot user or bot role can access the target channel and has these permissions: View Channel, Send Messages, Create Public Threads, Send Messages in Threads, and Read Message History.
 
 ### Commands not appearing in Discord
 


### PR DESCRIPTION
## Summary

README now clarifies that bots need access to private or restricted channels before `/opencode` can create threads.

## Related Issue

Closes #49

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added a setup note for private or restricted channel access.
- Added a concise troubleshooting note for the `Cannot create thread` error.
- Kept the update limited to the required channel access and thread permission guidance.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated tests (if applicable)
- [ ] All existing tests pass (`npm test`)

Reviewed the README diff and ran `git diff --check`.

## Checklist

- [x] My code follows the existing code style
- [x] I have not included version bumps (maintainer handles versioning)
- [x] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Screenshots (if applicable)

N/A

## Additional Notes

Docs-only change; no runtime behavior changes.