### PR TITLE
Feat/optional work description

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,13 @@ Start isolated work on a new branch with its own worktree.
 
 ```
 /work branch:feature/dark-mode description:Implement dark mode toggle
+/work branch:feature/dark-mode      # description defaults to the branch name
 ```
 
-| Parameter     | Description                         |
-| ------------- | ----------------------------------- |
-| `branch`      | Git branch name (will be sanitized) |
-| `description` | Brief description of the work       |
+| Parameter     | Description                                         |
+| ------------- | --------------------------------------------------- |
+| `branch`      | Git branch name (will be sanitized)                 |
+| `description` | Optional. Defaults to the branch name when omitted. |
 
 **Features:**
 

--- a/src/__tests__/work.test.ts
+++ b/src/__tests__/work.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChannelType } from 'discord.js';
+
+vi.mock('../services/dataStore.js');
+vi.mock('../services/worktreeManager.js');
+
+import { work } from '../commands/work.js';
+import * as dataStore from '../services/dataStore.js';
+import * as worktreeManager from '../services/worktreeManager.js';
+
+function makeInteraction(branch: string, description: string | null) {
+  const threadSend = vi.fn().mockResolvedValue(undefined);
+  const createdThread = { id: 'thread-1', send: threadSend };
+  const threadsCreate = vi.fn().mockResolvedValue(createdThread);
+
+  const channel = {
+    isThread: () => false,
+    type: ChannelType.GuildText,
+    threads: { create: threadsCreate },
+  };
+
+  const optsMap = new Map<string, string | null>([
+    ['branch', branch],
+    ['description', description],
+  ]);
+
+  return {
+    threadsCreate,
+    threadSend,
+    interaction: {
+      channelId: 'channel-1',
+      user: { id: 'user-1' },
+      channel,
+      options: {
+        getString: (name: string, _required?: boolean) => optsMap.get(name) ?? null,
+      },
+      reply: vi.fn().mockResolvedValue(undefined),
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as any,
+  };
+}
+
+describe('/work — description fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(worktreeManager.sanitizeBranchName).mockImplementation((b: string) => b);
+    vi.mocked(worktreeManager.createWorktree).mockResolvedValue('/tmp/worktree');
+    vi.mocked(dataStore.getChannelProjectPath).mockReturnValue('/tmp/project');
+    vi.mocked(dataStore.getWorktreeMappingByBranch).mockReturnValue(undefined);
+    vi.mocked(dataStore.setWorktreeMapping).mockReturnValue(undefined);
+  });
+
+  it('uses branch name as description when description is omitted', async () => {
+    const { interaction, threadsCreate } = makeInteraction('feat-foo', null);
+
+    await work.execute(interaction);
+
+    expect(threadsCreate.mock.calls[0][0].name).toBe('🌳 feat-foo: feat-foo');
+    const mapping = vi.mocked(dataStore.setWorktreeMapping).mock.calls[0][0];
+    expect(mapping.description).toBe('feat-foo');
+  });
+
+  it('falls back to branch name when description is whitespace-only', async () => {
+    const { interaction, threadsCreate } = makeInteraction('feat-bar', '   ');
+
+    await work.execute(interaction);
+
+    expect(threadsCreate.mock.calls[0][0].name).toBe('🌳 feat-bar: feat-bar');
+    const mapping = vi.mocked(dataStore.setWorktreeMapping).mock.calls[0][0];
+    expect(mapping.description).toBe('feat-bar');
+  });
+
+  it('uses provided description verbatim in the thread name', async () => {
+    const { interaction, threadsCreate } = makeInteraction('feat-baz', 'build the thing');
+
+    await work.execute(interaction);
+
+    expect(threadsCreate.mock.calls[0][0].name).toBe('🌳 feat-baz: build the thing');
+    const mapping = vi.mocked(dataStore.setWorktreeMapping).mock.calls[0][0];
+    expect(mapping.description).toBe('build the thing');
+  });
+
+  it('truncates the thread name to 100 characters', async () => {
+    const longDesc = 'x'.repeat(200);
+    const { interaction, threadsCreate } = makeInteraction('feat-long', longDesc);
+
+    await work.execute(interaction);
+
+    expect(threadsCreate.mock.calls[0][0].name.length).toBe(100);
+  });
+});

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -14,14 +14,15 @@ export const work: Command = {
     )
     .addStringOption(option =>
       option.setName('description')
-        .setDescription('Description of the work')
-        .setRequired(true)
+        .setDescription('Description of the work (defaults to branch name)')
+        .setRequired(false)
     ) as SlashCommandBuilder,
 
   execute: async (interaction: any) => {
     const i = interaction as ChatInputCommandInteraction;
     const branchInput = i.options.getString('branch', true);
-    const description = i.options.getString('description', true);
+    const sanitizedBranch = worktreeManager.sanitizeBranchName(branchInput);
+    const description = i.options.getString('description')?.trim() || sanitizedBranch;
 
     const channel = i.channel;
     if (!channel) {
@@ -53,8 +54,6 @@ export const work: Command = {
       });
       return;
     }
-
-    const sanitizedBranch = worktreeManager.sanitizeBranchName(branchInput);
 
     const existingMapping = dataStore.getWorktreeMappingByBranch(projectPath, sanitizedBranch);
     if (existingMapping) {


### PR DESCRIPTION
## Summary

Makes the `description` parameter on `/work` optional. When omitted (or whitespace-only), it falls back to the sanitized branch name so all downstream code paths continue to work without any conditional handling.

## Related Issue

Closes #55 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- `src/commands/work.ts`: `description` option is now `setRequired(false)`. The `sanitizedBranch` computation moved up so it's available immediately, and `description` is initialized from `i.options.getString('description')?.trim() || sanitizedBranch`. Downstream code (thread name, embed, persisted mapping) is unchanged.
- README updated to document the new optional parameter.
- Added unit tests covering omitted, whitespace-only, explicit distinct, and the 100-character thread-name truncation.

## Testing

- [x] I have tested this locally
- [x] I have added/updated tests (if applicable)
- [x] All existing tests pass (`npm test`)

Manual checks performed in a test guild:

- `/work branch:test-feature` → thread title `🌳 test-feature: test-feature`, embed shows `test-feature` as the description.
- `/work branch:test-feature description:"build the thing"` → thread title `🌳 test-feature: build the thing`, embed shows `build the thing`.
- `/work branch:test-feature description:"   "` → behaves like the omitted case (whitespace trimmed).

## Checklist

- [x] My code follows the existing code style
- [x] I have not included version bumps (maintainer handles versioning)
- [x] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Screenshots (if applicable)

N/A — slash-command parameter change with no UI surface beyond the existing thread title and embed (covered in the manual checks above).

## Additional Notes

The slash-command schema change (required → optional) is backward-compatible: existing invocations that pass `description` still work identically.

The implementation deliberately avoids any de-duplication or special-casing when the omitted-description fallback equals the branch name — the thread title in that case reads `🌳 foo: foo` and the embed shows `foo` as the description. This is a small redundancy in exchange for keeping `execute` linear and conditional-free; the fallback is a single one-liner at the top of the function.

Pre-merge review note: an earlier iteration of this PR was reviewed via three independent reviewers (Codex, Claude Opus, Kimi K2). None flagged correctness issues.