### PR TITLE
fix: Windows spawn EINVAL with paths containing spaces

### DIFF
--- a/src/services/serveManager.ts
+++ b/src/services/serveManager.ts
@@ -180,10 +180,16 @@ export async function spawnServe(
   console.log(`[opencode] Spawning: ${command} ${args.join(" ")}`);
   console.log(`[opencode] Working directory: ${projectPath}`);
 
-  const child = spawn(command, args, {
+  // Windows: wrap command in quotes when it contains spaces (shell:true path splitting issue)
+  const windowsCmd = process.platform === "win32" && command.includes(" ")
+    ? `"${command}"`
+    : command;
+
+  const child = spawn(windowsCmd, args, {
     cwd: projectPath,
     env,
     stdio: ["inherit", "pipe", "pipe"],
+    shell: true,
   });
 
   const instance: ServeInstance = {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does in 1-2 sentences -->

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Use "Closes #123" or "Fixes #123" to auto-close the issue when merged -->

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

<!-- List the specific changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this locally
- [ ] I have added/updated tests (if applicable)
- [ ] All existing tests pass (`npm test`)

## Checklist

- [ ] My code follows the existing code style
- [ ] I have not included version bumps (maintainer handles versioning)
- [ ] I have updated documentation if needed
- [x] This PR focuses on a single feature/fix

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

Fixes **Windows spawn EINVAL** errors when OpenCode is installed in paths with spaces (e.g. C:\Program Files\).

**Errors fixed:**
1. \`spawn EINVAL\` - spawn() without \`shell: true\` cannot execute .cmd shims on Windows
2. \`"C:\Program" is not recognized as an internal or external command\` - \`shell: true\` without quoting paths with spaces causes Windows to split the command
