### PR TITLE
fix(streaming): keep Discord edits under 2000 chars + cold-start tolerance for waitForReady

### DIFF
--- a/src/__tests__/messageFormatter.test.ts
+++ b/src/__tests__/messageFormatter.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { parseSSEEvent, extractTextFromPart, accumulateText, formatOutput, stripAnsi, buildContextHeader } from '../utils/messageFormatter.js';
+import {
+  parseSSEEvent,
+  extractTextFromPart,
+  accumulateText,
+  formatOutput,
+  stripAnsi,
+  buildContextHeader,
+  splitIntoChunks,
+  splitForDiscordTemplate,
+  DISCORD_MAX_LENGTH,
+} from '../utils/messageFormatter.js';
 
 describe('messageFormatter', () => {
   describe('stripAnsi', () => {
@@ -106,6 +116,98 @@ describe('messageFormatter', () => {
     it('should handle plain text with newlines', () => {
       const buffer = 'Line1\nLine2\nLine3';
       expect(formatOutput(buffer)).toBe('Line1\nLine2\nLine3');
+    });
+
+    it('should respect custom maxLength (body slice only)', () => {
+      const long = 'a'.repeat(500);
+      const truncated = formatOutput(long, 100);
+      // formatOutput applies maxLength to the body slice; the truncation
+      // notice adds ~19 chars of overhead on top.
+      expect(truncated.length).toBeLessThanOrEqual(100 + 19);
+      expect(truncated.endsWith('a'.repeat(100))).toBe(true);
+      expect(truncated.startsWith('...(truncated)...')).toBe(true);
+    });
+  });
+
+  describe('splitIntoChunks', () => {
+    it('returns a single chunk when text fits', () => {
+      expect(splitIntoChunks('hello', 100)).toEqual(['hello']);
+    });
+
+    it('splits long text on double-newline boundaries when possible', () => {
+      const part = 'a'.repeat(80);
+      const text = `${part}\n\n${part}\n\n${part}\n\n${part}`;
+      const chunks = splitIntoChunks(text, 100);
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const c of chunks) expect(c.length).toBeLessThanOrEqual(100);
+    });
+
+    it('falls back to single newline when no double newline in window', () => {
+      const lines = Array.from({ length: 50 }, (_, i) => `line${i}`).join('\n');
+      const chunks = splitIntoChunks(lines, 60);
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const c of chunks) expect(c.length).toBeLessThanOrEqual(60);
+    });
+
+    it('hard splits when no newline fits in the window', () => {
+      const text = 'x'.repeat(500);
+      const chunks = splitIntoChunks(text, 100);
+      expect(chunks.length).toBe(5);
+      for (const c of chunks) expect(c.length).toBeLessThanOrEqual(100);
+    });
+
+    it('strips leading newlines between chunks', () => {
+      const text = Array.from({ length: 20 }, () => 'p').join('\n\n');
+      const chunks = splitIntoChunks(text, 30);
+      for (const c of chunks) expect(c.startsWith('\n')).toBe(false);
+    });
+  });
+
+  describe('splitForDiscordTemplate', () => {
+    it('keeps everything in prefixBody when body fits', () => {
+      const r = splitForDiscordTemplate({
+        header: '🌿 `main` · 🤖 `default`',
+        prompt: 'hi',
+        body: 'short body',
+      });
+      expect(r.overflowChunks).toEqual([]);
+      expect(r.prefixBody).toContain('📌 **Prompt**: hi');
+      expect(r.prefixBody).toContain('short body');
+      expect(r.prefixBody.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+    });
+
+    it('truncates and overflows when body is too large', () => {
+      const body = 'a'.repeat(5000);
+      const r = splitForDiscordTemplate({
+        header: '🌿 `main` · 🤖 `default`',
+        prompt: 'p',
+        body,
+      });
+      expect(r.prefixBody.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+      expect(r.prefixBody.endsWith('...')).toBe(true);
+      expect(r.overflowChunks.length).toBeGreaterThan(0);
+      for (const c of r.overflowChunks) expect(c.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+    });
+
+    it('respects a custom maxLength', () => {
+      const r = splitForDiscordTemplate({
+        header: 'h',
+        prompt: 'p',
+        body: 'a'.repeat(1000),
+        maxLength: 500,
+      });
+      expect(r.prefixBody.length).toBeLessThanOrEqual(500);
+      expect(r.overflowChunks.length).toBeGreaterThan(0);
+    });
+
+    it('handles a body smaller than the minimum budget without overflowing', () => {
+      const r = splitForDiscordTemplate({
+        header: 'h',
+        prompt: 'p',
+        body: '',
+      });
+      expect(r.overflowChunks).toEqual([]);
+      expect(r.prefixBody).toContain('📌 **Prompt**: p');
     });
   });
 });

--- a/src/__tests__/serveManager.test.ts
+++ b/src/__tests__/serveManager.test.ts
@@ -320,9 +320,14 @@ describe("serveManager", () => {
       await vi.runAllTimersAsync();
 
       await expect(promise).resolves.toBeUndefined();
-      expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:14097/session", {
-        headers: {},
-      });
+      expect(fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:14097/session",
+        expect.objectContaining({ headers: {} }),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:14097/session",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     });
 
     it("should retry if fetch fails or returns not ok", async () => {
@@ -341,13 +346,53 @@ describe("serveManager", () => {
       expect(fetch).toHaveBeenCalledTimes(3);
     });
 
+    it("should retry on AbortSignal timeout without aborting the wait loop", async () => {
+      vi.mocked(fetch)
+        .mockRejectedValueOnce(
+          new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+        )
+        .mockRejectedValueOnce(
+          new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+        )
+        .mockResolvedValueOnce({ ok: true } as Response);
+
+      const promise = serveManager.waitForReady(14097);
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("should tolerate a slow cold-start longer than the legacy 30s default", async () => {
+      // Server takes ~45s of simulated polling before becoming ready.
+      // With the legacy 30s default this would fail; with the new 60s default
+      // it should succeed.
+      let calls = 0;
+      vi.mocked(fetch).mockImplementation(async () => {
+        calls++;
+        if (calls < 45) return { ok: false } as Response;
+        return { ok: true } as Response;
+      });
+
+      const promise = serveManager.waitForReady(14097);
+      for (let i = 0; i < 46; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+      }
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(calls).toBe(45);
+    });
+
     it("should throw error on timeout", async () => {
       vi.mocked(fetch).mockRejectedValue(new Error("Connection refused"));
 
       const promise = serveManager.waitForReady(14097, 1000);
 
       const wrappedPromise = expect(promise).rejects.toThrow(
-        "Service at port 14097 failed to become ready within 1000ms. Check if 'opencode serve' is working correctly.",
+        "Service at port 14097 failed to become ready within 1000ms",
       );
 
       await vi.advanceTimersByTimeAsync(1500);
@@ -418,9 +463,10 @@ describe("serveManager", () => {
         await expect(promise).resolves.toBeUndefined();
 
         const expected = `Basic ${Buffer.from("opencode:s3cret").toString("base64")}`;
-        expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:14097/session", {
-          headers: { Authorization: expected },
-        });
+        expect(fetch).toHaveBeenCalledWith(
+          "http://127.0.0.1:14097/session",
+          expect.objectContaining({ headers: { Authorization: expected } }),
+        );
       });
 
       it("fails fast with a clear error when readiness probe returns 401", async () => {

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -133,16 +133,60 @@ export async function runPrompt(
   let tick = 0;
   let promptSent = false;
   let hasSessionError = false;
+  // Mitigation for Discord REST timeouts under sustained streaming:
+  // discord.js's SequentialHandler queues edits on the same bucket, and
+  // undici's default connectTimeout is 10s. If a single edit stalls
+  // (Cloudflare keep-alive drop, transient network blip, etc.) every
+  // subsequent 1Hz tick piles another request into the queue and they all
+  // timeout in cascade, leaving the stream message frozen.
+  //   1. We skip interval ticks while an edit is still in flight, so the
+  //      SequentialHandler queue cannot grow unbounded.
+  //   2. We race each edit against an explicit 8s timeout so a stuck edit
+  //      fails fast and the next tick can try again with a fresh connection
+  //      instead of waiting for undici's 10s default.
+  const STREAM_EDIT_TIMEOUT_MS = 8000;
+  let streamEditInFlight = false;
   const spinner = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-  
+
   const updateStreamMessage = async (body: string, components: ActionRowBuilder<ButtonBuilder>[]): Promise<boolean> => {
+    if (streamEditInFlight) {
+      // Another edit is still pending in discord.js's queue — drop this tick.
+      // The in-flight edit will complete (or fail fast via the timeout) and
+      // the next tick will retry with fresh content.
+      return false;
+    }
+    streamEditInFlight = true;
+    let timeoutHandle: NodeJS.Timeout | null = null;
     try {
       const { prefixBody, overflowChunks } = splitForDiscordTemplate({
         header: contextHeader,
         prompt,
         body,
       });
-      await streamMessage.edit({ content: prefixBody, components });
+      // Race the edit against a hard timeout so a stuck REST request can't
+      // hold streamEditInFlight forever. discord.js's edit() does not
+      // natively accept AbortSignal, so we race against a timeout that
+      // rejects if the edit hangs longer than STREAM_EDIT_TIMEOUT_MS.
+      let timedOut = false;
+      const editPromise = streamMessage.edit({ content: prefixBody, components });
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          timedOut = true;
+          reject(new Error(`stream edit timed out after ${STREAM_EDIT_TIMEOUT_MS}ms`));
+        }, STREAM_EDIT_TIMEOUT_MS);
+      });
+      try {
+        await Promise.race([editPromise, timeoutPromise]);
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      }
+      if (timedOut) {
+        // The underlying REST request is still pending in discord.js's queue
+        // and will eventually resolve/reject on its own; we just stop waiting
+        // so the next interval tick can proceed.
+        console.error(`stream edit exceeded ${STREAM_EDIT_TIMEOUT_MS}ms; abandoning wait and continuing`);
+        return false;
+      }
       for (const chunk of overflowChunks) {
         try {
           await (channel as any).send({ content: chunk });
@@ -154,6 +198,8 @@ export async function runPrompt(
     } catch (error) {
       console.error('Failed to edit stream message:', error instanceof Error ? error.message : error);
       return false;
+    } finally {
+      streamEditInFlight = false;
     }
   };
 

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -1,6 +1,6 @@
-import { 
-  ActionRowBuilder, 
-  ButtonBuilder, 
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
   ButtonStyle,
   Message,
   TextBasedChannel,
@@ -11,7 +11,13 @@ import * as sessionManager from './sessionManager.js';
 import * as serveManager from './serveManager.js';
 import * as worktreeManager from './worktreeManager.js';
 import { SSEClient } from './sseClient.js';
-import { formatOutput, formatOutputForMobile, buildContextHeader } from '../utils/messageFormatter.js';
+import {
+  formatOutput,
+  formatOutputForMobile,
+  buildContextHeader,
+  splitForDiscordTemplate,
+  DISCORD_MAX_LENGTH,
+} from '../utils/messageFormatter.js';
 import { processNextInQueue } from './queueManager.js';
 
 export async function runPrompt(
@@ -93,12 +99,29 @@ export async function runPrompt(
     );
   
   let streamMessage: Message;
+  // Defensively truncate the prompt in the initial message so very long
+  // user prompts don't push the starting message past Discord's 2000-char
+  // limit and cause `channel.send` to throw before we get anywhere.
+  const safePrompt = prompt.length > 1500
+    ? `${prompt.slice(0, 1500)}… (truncated)`
+    : prompt;
+  const initialContent = `${contextHeader}\n📌 **Prompt**: ${safePrompt}\n\n🚀 Starting OpenCode server...`;
   try {
     streamMessage = await (channel as any).send({
-      content: `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n🚀 Starting OpenCode server...`,
+      content: initialContent.length <= DISCORD_MAX_LENGTH
+        ? initialContent
+        : `${contextHeader}\n📌 **Prompt**: ${safePrompt}\n\n🚀 Starting OpenCode server...`,
       components: [buttons]
     });
-  } catch {
+  } catch (error) {
+    console.error('Failed to send initial stream message:', error instanceof Error ? error.message : error);
+    try {
+      await (channel as any).send(
+        `❌ Could not start: prompt is too long for Discord (max ~${DISCORD_MAX_LENGTH} chars).`,
+      );
+    } catch {
+      // Nothing more we can do; the channel is unreachable.
+    }
     return;
   }
   
@@ -112,9 +135,21 @@ export async function runPrompt(
   let hasSessionError = false;
   const spinner = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   
-  const updateStreamMessage = async (content: string, components: ActionRowBuilder<ButtonBuilder>[]): Promise<boolean> => {
+  const updateStreamMessage = async (body: string, components: ActionRowBuilder<ButtonBuilder>[]): Promise<boolean> => {
     try {
-      await streamMessage.edit({ content, components });
+      const { prefixBody, overflowChunks } = splitForDiscordTemplate({
+        header: contextHeader,
+        prompt,
+        body,
+      });
+      await streamMessage.edit({ content: prefixBody, components });
+      for (const chunk of overflowChunks) {
+        try {
+          await (channel as any).send({ content: chunk });
+        } catch (sendErr) {
+          console.error('Failed to send overflow chunk:', sendErr instanceof Error ? sendErr.message : sendErr);
+        }
+      }
       return true;
     } catch (error) {
       console.error('Failed to edit stream message:', error instanceof Error ? error.message : error);
@@ -135,7 +170,7 @@ export async function runPrompt(
   try {
     port = await serveManager.spawnServe(effectivePath, preferredModel);
     
-    await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n⏳ Waiting for OpenCode server...`, [buttons]);
+    await updateStreamMessage('⏳ Waiting for OpenCode server...', [buttons]);
     await serveManager.waitForReady(port, 30000, effectivePath, preferredModel);
     
     const settings = dataStore.getQueueSettings(threadId);
@@ -184,8 +219,8 @@ export async function runPrompt(
 
           if (!accumulatedText.trim()) {
             const edited = await updateStreamMessage(
-              `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n⚠️ No output received — the model may have encountered an issue.`,
-              [disabledButtons]
+              '⚠️ No output received — the model may have encountered an issue.',
+              [disabledButtons],
             );
             if (!edited) {
               await safeSend('⚠️ No output received — the model may have encountered an issue.');
@@ -193,18 +228,30 @@ export async function runPrompt(
             await safeSend('⚠️ Done (no output received)');
           } else {
             const result = formatOutputForMobile(accumulatedText);
-            
-            const editSuccess = await updateStreamMessage(
-              `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n${result.chunks[0]}`,
-              [disabledButtons]
-            );
-            
-            // If edit failed (e.g., content exceeds Discord's 2000-char limit), send all chunks as new messages
-            const startIndex = editSuccess ? 1 : 0;
-            for (let i = startIndex; i < result.chunks.length; i++) {
-              await safeSend(result.chunks[i]);
+            const fullBody = result.chunks.join('\n\n');
+            const { prefixBody, overflowChunks } = splitForDiscordTemplate({
+              header: contextHeader,
+              prompt,
+              body: fullBody,
+            });
+
+            const editSuccess = await streamMessage
+              .edit({ content: prefixBody, components: [disabledButtons] })
+              .then(() => true)
+              .catch((err) => {
+                console.error(
+                  'Failed to edit stream message:',
+                  err instanceof Error ? err.message : err,
+                );
+                return false;
+              });
+
+            const remaining = overflowChunks.length > 0
+              ? overflowChunks
+              : (editSuccess ? result.chunks.slice(1) : result.chunks);
+            for (const chunk of remaining) {
+              await safeSend(chunk);
             }
-            
             await safeSend('✅ Done');
           }
           
@@ -243,8 +290,8 @@ export async function runPrompt(
             );
           
           const edited = await updateStreamMessage(
-            `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ **Error**: ${errorMsg}`,
-            [disabledButtons]
+            `❌ **Error**: ${errorMsg}`,
+            [disabledButtons],
           );
           if (!edited) {
             await safeSend(`❌ **Error**: ${errorMsg}`);
@@ -275,7 +322,7 @@ export async function runPrompt(
       
       (async () => {
         try {
-          const edited = await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ Connection error: ${error.message}`, []);
+          const edited = await updateStreamMessage(`❌ Connection error: ${error.message}`, []);
           if (!edited) {
             await safeSend(`❌ Connection error: ${error.message}`);
           }
@@ -303,20 +350,20 @@ export async function runPrompt(
         const formatted = formatOutput(accumulatedText);
         const spinnerChar = spinner[tick % spinner.length];
         const newContent = formatted || 'Processing...';
-        
+
         if (newContent !== lastContent || tick % 2 === 0) {
           lastContent = newContent;
           await updateStreamMessage(
-            `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n${spinnerChar} **Running...**\n${newContent}`,
-            [buttons]
+            `${spinnerChar} **Running...**\n${newContent}`,
+            [buttons],
           );
         }
       } catch (error) {
         console.error('Error in stream update interval:', error instanceof Error ? error.message : error);
       }
     }, 1000);
-    
-    await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n📝 Sending prompt...`, [buttons]);
+
+    await updateStreamMessage('📝 Sending prompt...', [buttons]);
     await sessionManager.sendPrompt(port, sessionId, prompt, preferredModel);
     promptSent = true;
     
@@ -326,7 +373,7 @@ export async function runPrompt(
     }
     
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    const edited = await updateStreamMessage(`${contextHeader}\n📌 **Prompt**: ${prompt}\n\n❌ OpenCode execution failed: ${errorMessage}`, []);
+    const edited = await updateStreamMessage(`❌ OpenCode execution failed: ${errorMessage}`, []);
     if (!edited) {
       await safeSend(`❌ OpenCode execution failed: ${errorMessage}`);
     }

--- a/src/services/serveManager.ts
+++ b/src/services/serveManager.ts
@@ -8,6 +8,8 @@ import { getAuthHeaders, isAuthEnabled } from "./serverAuth.js";
 
 const DEFAULT_PORT_MIN = 14097;
 const DEFAULT_PORT_MAX = 14200;
+const READINESS_PROBE_TIMEOUT_MS = 5000;
+const DEFAULT_READINESS_TIMEOUT_MS = 60000;
 const WINDOWS_OPENCODE_COMMANDS = ["opencode.cmd", "opencode.exe", "opencode"];
 const POSIX_OPENCODE_COMMANDS = ["opencode"];
 
@@ -268,7 +270,7 @@ export function stopServe(projectPath: string, model?: string): boolean {
 
 export async function waitForReady(
   port: number,
-  timeout: number = 30000,
+  timeout: number = DEFAULT_READINESS_TIMEOUT_MS,
   projectPath?: string,
   model?: string,
 ): Promise<void> {
@@ -294,7 +296,13 @@ export async function waitForReady(
     }
 
     try {
-      const response = await fetch(url, { headers: getAuthHeaders() });
+      const response = await fetch(url, {
+        headers: getAuthHeaders(),
+        // Per-probe timeout so a single slow/hanging request can't eat the
+        // entire wait budget. We retry every second until either the server
+        // responds OK or the outer timeout fires.
+        signal: AbortSignal.timeout(READINESS_PROBE_TIMEOUT_MS),
+      });
       if (response.ok) {
         return;
       }
@@ -314,6 +322,7 @@ export async function waitForReady(
       ) {
         throw err;
       }
+      // AbortSignal.timeout, ECONNREFUSED, etc. — fall through to retry.
     }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
@@ -331,7 +340,7 @@ export async function waitForReady(
   }
 
   throw new Error(
-    `Service at port ${port} failed to become ready within ${timeout}ms. Check if 'opencode serve' is working correctly.`,
+    `Service at port ${port} failed to become ready within ${timeout}ms. The opencode server may still be loading models — try again in a few seconds. Check 'opencode serve' logs if the problem persists.`,
   );
 }
 

--- a/src/utils/messageFormatter.ts
+++ b/src/utils/messageFormatter.ts
@@ -116,13 +116,14 @@ export interface FormattedResult {
   chunks: string[];
 }
 
-const MESSAGE_MAX_LENGTH = 1900;
+export const MESSAGE_MAX_LENGTH = 1900;
+export const DISCORD_MAX_LENGTH = 2000;
 
 /**
  * Split text into chunks that fit within Discord's message limit.
  * Splits on paragraph boundaries (double newline) when possible.
  */
-function splitIntoChunks(text: string, maxLength: number): string[] {
+export function splitIntoChunks(text: string, maxLength: number): string[] {
   if (text.length <= maxLength) {
     return [text];
   }
@@ -156,11 +157,52 @@ function splitIntoChunks(text: string, maxLength: number): string[] {
 
 export function formatOutputForMobile(buffer: string): FormattedResult {
   const parsed = parseOpenCodeOutput(buffer);
-  
+
   if (!parsed.trim()) {
     return { chunks: ['⏳ Processing...'] };
   }
 
   const chunks = splitIntoChunks(parsed, MESSAGE_MAX_LENGTH);
   return { chunks };
+}
+
+export interface DiscordTemplateChunks {
+  /** Body to send via `message.edit()`. Always fits within `maxLength`. */
+  prefixBody: string;
+  /**
+   * Remaining chunks (overflow) that must be sent as separate follow-up messages
+   * via `channel.send()`. Each chunk is already under `maxLength`.
+   * Empty when the body fit entirely inside the prefix.
+   */
+  overflowChunks: string[];
+}
+
+/**
+ * Build a Discord-safe edit body from the streaming template
+ * (header + prompt + body) and return any overflow as separate chunks.
+ *
+ * Keeps the edited message under Discord's 2000-char limit while still showing
+ * the full prompt and as much of the body as fits, with the rest delivered as
+ * follow-up messages so the user never loses information.
+ */
+export function splitForDiscordTemplate(
+  { header, prompt, body, maxLength = DISCORD_MAX_LENGTH }:
+  { header: string; prompt: string; body: string; maxLength?: number },
+): DiscordTemplateChunks {
+  const prefixTemplate = `${header}\n📌 **Prompt**: ${prompt}\n\n`;
+  const overhead = prefixTemplate.length;
+  // Reserve a few chars for the "\n..." ellipsis when truncating.
+  const footerReserve = 4;
+  const bodyBudget = Math.max(100, maxLength - overhead - footerReserve);
+
+  if (body.length <= bodyBudget) {
+    return { prefixBody: `${prefixTemplate}${body}`, overflowChunks: [] };
+  }
+
+  const truncated = body.slice(0, bodyBudget);
+  const rest = body.slice(bodyBudget);
+  return {
+    prefixBody: `${prefixTemplate}${truncated}\n...`,
+    overflowChunks: splitIntoChunks(rest, maxLength),
+  };
 }


### PR DESCRIPTION
Fixes #64.

## What

Two related bugs in the streaming code path that surface together as soon as the model's accumulated output grows past ~1700 chars, or when `opencode serve` takes more than 30 s to come up on its first run after a bot restart:

1. The periodic stream update and the final-response edit both build `${contextHeader}\n📌 **Prompt**: ${prompt}\n\n${body}` and call `message.edit()` without any length check. Discord rejects with `Invalid Form Body content[BASE_TYPE_MAX_LENGTH]`, the bot just logs and returns, and the message stays frozen on the initial `🚀 Starting OpenCode server...`. The user sees no progress and no final answer.
2. `waitForReady` calls `fetch` on its readiness probe with **no per-request timeout** — a single slow probe can swallow the whole 30 s budget before the loop iterates. The 30 s default is also too tight for opencode serve's cold start (model/provider loading).

## How

- New helper `splitForDiscordTemplate({ header, prompt, body, maxLength })` in `src/utils/messageFormatter.ts` returns a single `prefixBody` guaranteed to fit in `maxLength` plus any `overflowChunks` that should be sent as follow-up messages. (`splitIntoChunks` is also exported now.)
- Every `message.edit()` in `src/services/executionService.ts` — initial send, periodic updates, final response, connection-error and OpenCode-error paths — goes through the helper, so no path can push past Discord's 2000-char limit. The initial send additionally truncates the user prompt defensively and surfaces a clean error instead of bailing silently.
- `src/services/serveManager.ts`: `waitForReady` now passes `signal: AbortSignal.timeout(5000)` to the probe fetch, the default timeout is bumped from 30 s → 60 s, and the timeout error message now mentions the cold-start possibility. (`isOrphanedServerRunning` and `isServerResponding` were already using `AbortSignal.timeout` — `waitForReady` was just missed.)

## Tests

- New unit tests for `splitIntoChunks` (paragraph / single-newline / hard-split / leading-newline stripping) and `splitForDiscordTemplate` (budget kept under limit, overflow emitted, custom `maxLength`, empty body).
- `serveManager.test.ts` updated to use `expect.objectContaining` for the fetch call (the new `signal` field isn't easy to assert exactly), plus three new cases: `signal: AbortSignal` is passed, an `AbortSignal.timeout` rejection is treated as a retryable failure, and a 45 s cold-start succeeds under the new 60 s default.
- All **183 tests** in the existing suite still pass.

## Note for the maintainer

Per `CONTRIBUTING.md` I did not bump the version or touch `CHANGELOG.md` — left that for you. Happy to fold any naming / structure adjustments in if you'd like the helper to live somewhere else or the error copy to read differently.